### PR TITLE
visually-hidden: use :has since focusable element is a child of :host

### DIFF
--- a/_components/visually-hidden.webc
+++ b/_components/visually-hidden.webc
@@ -2,7 +2,7 @@
 /* https://www.a11yproject.com/posts/how-to-hide-content/ */
 /* https://blog.logrocket.com/design-accessibility-css-visually-hidden-class/ */
 /* https://front-end.social/@joshwcomeau/112574609127860924 */
-:host:not(:focus) {
+:host:not(:has(:is(a:active, a:focus))) {
 	clip: rect(0 0 0 0);
 	clip-path: inset(50%);
 	height: 1px;
@@ -10,5 +10,8 @@
 	position: absolute;
 	white-space: nowrap;
 	width: 1px;
+}
+:host:has(:is(a:active, a:focus)) {
+  margin: var(--box-margin);
 }
 </style>


### PR DESCRIPTION
Thanks MDN, [:has() > With the :is() pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:has#with_the_is_pseudo-class)