### PR TITLE
accessible-emoji: use conditional (ternary) operator for brevity

### DIFF
--- a/_components/accessible-emoji.webc
+++ b/_components/accessible-emoji.webc
@@ -1,10 +1,6 @@
 <script webc:root="override" webc:type="js" webc:raw>
 let label = "";
-if (alt) {
-	label = alt.toString();
-} else {
-	label = emojiShortName(emoji);
-}
+alt ? label = alt.toString() : label = emojiShortName(emoji);
 // via
 // https://kittygiraudel.com/2021/01/02/accessible-emojis-with-11ty/
 // https://tink.uk/accessible-emoji/

--- a/_components/accessible-emoji.webc
+++ b/_components/accessible-emoji.webc
@@ -1,7 +1,6 @@
 <script webc:root="override" webc:type="js" webc:raw>
 let label = "";
 alt ? label = alt.toString() : label = emojiShortName(emoji);
-// via
 // https://kittygiraudel.com/2021/01/02/accessible-emojis-with-11ty/
 // https://tink.uk/accessible-emoji/
 // https://adrianroselli.com/2016/12/accessible-emoji-tweaked.html

--- a/_components/visually-hidden.webc
+++ b/_components/visually-hidden.webc
@@ -1,17 +1,17 @@
 <style webc:scoped>
+	:host:not(:has(:is(a:active, a:focus))) {
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		height: 1px;
+		overflow: hidden;
+		position: absolute;
+		white-space: nowrap;
+		width: 1px;
+	}
+	:host:has(:is(a:active, a:focus)) {
+		margin: var(--box-margin);
+	}
 /* https://www.a11yproject.com/posts/how-to-hide-content/ */
 /* https://blog.logrocket.com/design-accessibility-css-visually-hidden-class/ */
 /* https://front-end.social/@joshwcomeau/112574609127860924 */
-:host:not(:has(:is(a:active, a:focus))) {
-	clip: rect(0 0 0 0);
-	clip-path: inset(50%);
-	height: 1px;
-	overflow: hidden;
-	position: absolute;
-	white-space: nowrap;
-	width: 1px;
-}
-:host:has(:is(a:active, a:focus)) {
-  margin: var(--box-margin);
-}
 </style>


### PR DESCRIPTION
- 1d2c46c [accessible-emoji: use conditional (ternary) operator for brevity](https://github.com/rdela/webcbed/commit/1d2c46c0a32494e95c242b245c91935737140361)
- e27c522 [useless line](https://github.com/rdela/webcbed/commit/e27c5221f3a1b82ee17e3b9204b3871b8b0bb35b)
- 56f7f28 [visually-hidden: bump comments down to the end](https://github.com/rdela/webcbed/commit/56f7f28d5e75a084812a9e8366af81aa3fff81be)