### PR TITLE
use <div> for styling wrapper in base.webc section.box

### DIFF
--- a/_includes/base.webc
+++ b/_includes/base.webc
@@ -15,7 +15,7 @@
 	</visually-hidden>
 
 	<section class="box">
-		<section>
+		<div>
 			<header>
 				<h1>
 					<a href="https://www.11ty.dev/docs/languages/webc/">WebC</a> bed 
@@ -25,7 +25,7 @@
 			</header>
 
 			<main id="skip" @raw="content"></main>
-		</section>
+		</div>
 
 		<footer>
 			<span><a :href="metadata.repo" @text="metadata.title + '&nbsp;' + metadata.version"></a> +</span>


### PR DESCRIPTION
instead of `<section>`:

> If you are only using the element as a styling wrapper, use a `<div>` instead.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section#usage_notes